### PR TITLE
PR/14 Cleanup whitespace and imports

### DIFF
--- a/client/pdf_generator.py
+++ b/client/pdf_generator.py
@@ -48,7 +48,7 @@ class Plugin(plugins.ClientPlugin):
 		),
 		plugins.ClientOptionString(
 			'logo',
-			'platypus.Image to include into the pdf',
+			'Image to include into the pdf',
 			display_name='Logo platypus.Image'
 		),
 		plugins.ClientOptionString(

--- a/client/pdf_generator.py
+++ b/client/pdf_generator.py
@@ -1,4 +1,3 @@
-#!/usr/bin/python3
 import time
 import os
 
@@ -8,13 +7,11 @@ import king_phisher.client.plugins as plugins
 import jinja2.exceptions
 
 try:
+	from reportlab import platypus
+	from reportlab.lib import styles
 	from reportlab.lib.enums import TA_JUSTIFY
 	from reportlab.lib.pagesizes import letter
-	from reportlab.platypus import SimpleDocTemplate, Paragraph, Spacer, Image
-	from reportlab.lib.styles import getSampleStyleSheet
 	from reportlab.lib.units import inch
-	from reportlab import platypus
-	from  reportlab.lib.styles import ParagraphStyle as PS
 except ImportError:
 	has_reportlab = False
 else:
@@ -30,10 +27,10 @@ class Plugin(plugins.ClientPlugin):
 	authors = ['Jeremy Schoeneman']
 	title = 'Generate PDF'
 	description = """
-	Generates a PDF file with a link which includes the campaign url with the individual 
-	message_id required to track individual visits to a website. Visit 
-	https://github.com/y4utj4/pdf_generator for example template files to use for this 
-	plugin
+	Generates a PDF file with a link which includes the campaign url with the
+	individual message_id required to track individual visits to a website.
+	Visit https://github.com/y4utj4/pdf_generator for example template files to
+	use for this plugin.
 	"""
 	homepage = 'https://github.com/securestate/king-phisher-plugins'
 	options = [
@@ -51,21 +48,20 @@ class Plugin(plugins.ClientPlugin):
 		),
 		plugins.ClientOptionString(
 			'logo',
-			'Image to include into the pdf',
-			display_name="Logo Image"
+			'platypus.Image to include into the pdf',
+			display_name='Logo platypus.Image'
 		),
 		plugins.ClientOptionString(
 			'link_text',
 			'Text for inserted link',
 			default='Click here to accept',
-			display_name="Link Text"
+			display_name='Link Text'
 		)
 	]
 	req_min_version = '1.7.0b1'
 	req_packages = {
-			'reportlab': has_reportlab
+		'reportlab': has_reportlab
 	}
-
 	def initialize(self):
 		mailer_tab = self.application.main_tabs['mailer']
 		self.text_insert = mailer_tab.tabs['send_messages'].text_insert
@@ -76,26 +72,25 @@ class Plugin(plugins.ClientPlugin):
 		return True
 
 	def signal_send_precheck(self, _):
-		if not any((self.config['template_file'], self.config['output_pdf'], self.config['link_text'])):
+		if not all((self.config['template_file'], self.config['output_pdf'], self.config['link_text'])):
 			self.logger.debug('skipping exporting any attachments due to lack of information provided to run')
 			return True
 
 		if self.config['logo'] and not os.path.isfile(self.config['template_file']):
 			self.logger.error('specified template or logo file not found')
 			return
-		else:
-			self.logger.debug('pdf template file found, generating attachment')
-			return True
+		self.logger.debug('pdf template file found, generating attachment')
+		return True
 
 	def make_preview(self, _):
 		outfile = self.expand_path(self.config['output_pdf'])
-		pdf_file = SimpleDocTemplate(outfile, 
-					pagesize=letter,
-					rightMargin=72, 
-					leftMargin=72,
-					topMargin=72, 
-					bottomMargin=18
-					)
+		pdf_file = platypus.SimpleDocTemplate(outfile,
+			pagesize=letter,
+			rightMargin=72,
+			leftMargin=72,
+			topMargin=72,
+			bottomMargin=18
+		)
 		url = self.application.config['mailer.webserver_url']
 		pdf = self.get_template(url)
 		pdf_file.multiBuild(pdf)
@@ -103,13 +98,13 @@ class Plugin(plugins.ClientPlugin):
 
 	def signal_send_target(self, _, target):
 		outfile = self.expand_path(self.config['output_pdf'])
-		pdf_file = SimpleDocTemplate(outfile, 
-					pagesize=letter,
-					rightMargin=72,
-					leftMargin=72,
-					topMargin=72,
-					bottomMargin=18
-					)
+		pdf_file = platypus.SimpleDocTemplate(outfile,
+			pagesize=letter,
+			rightMargin=72,
+			leftMargin=72,
+			topMargin=72,
+			bottomMargin=18
+		)
 		url = self.application.config['mailer.webserver_url'] + '?uid=' + target.uid
 		pdf = self.get_template(url)
 		try:
@@ -130,29 +125,29 @@ class Plugin(plugins.ClientPlugin):
 		click_me = self.config['link_text']
 		link = '<font color=blue><link href="' + str(url) + '">' + click_me + '</link></font>'
 		if self.config['logo']:
-			im = Image(logo, 2 * inch, inch)
+			im = platypus.Image(logo, 2 * inch, inch)
 			story.append(im)
 
-		styles = getSampleStyleSheet()
-		styles.add(PS(name='Justify', alignment=TA_JUSTIFY))
-		ptext = '<font size=10>%s</font>' % formatted_time
-		story.append(Spacer(1, 12))
-		story.append(Paragraph(ptext, styles["Normal"]))
-		story.append(Spacer(1, 12))
-		with open(self.config['template_file'], 'r') as t:
-			for line in t:
-				story.append(Paragraph(line, styles["Normal"]))
-		story.append(Spacer(1, 8))
-		story.append(platypus.Paragraph(link, styles["Justify"]))
-		story.append(Spacer(1, 12))
+		style_sheet = styles.getSampleStyleSheet()
+		style_sheet.add(styles.ParagraphStyle(name='Justify', alignment=TA_JUSTIFY))
+		ptext = '<font size=10>' + formatted_time + '</font>'
+		story.append(platypus.Spacer(1, 12))
+		story.append(platypus.Paragraph(ptext, style_sheet['Normal']))
+		story.append(platypus.Spacer(1, 12))
+		with open(self.config['template_file'], 'r') as file_h:
+			for line in file_h:
+				story.append(platypus.Paragraph(line, style_sheet['Normal']))
+		story.append(platypus.Spacer(1, 8))
+		story.append(platypus.Paragraph(link, style_sheet['Justify']))
+		story.append(platypus.Spacer(1, 12))
 		ptext = '<font size=10>Sincerely,</font>'
-		story.append(Paragraph(ptext, styles["Normal"]))
-		story.append(Spacer(1, 12))
-		ptext = '<font size=10>'+ sender + '</font>'
-		story.append(Paragraph(ptext, styles["Normal"]))
-		story.append(Spacer(1, 12))
+		story.append(platypus.Paragraph(ptext, style_sheet['Normal']))
+		story.append(platypus.Spacer(1, 12))
+		ptext = '<font size=10>' + sender + '</font>'
+		story.append(platypus.Paragraph(ptext, style_sheet['Normal']))
+		story.append(platypus.Spacer(1, 12))
 		ptext = '<font size=10>' + company + '</font>'
-		story.append(Paragraph(ptext, styles["Normal"]))
+		story.append(platypus.Paragraph(ptext, style_sheet['Normal']))
 		return story
 
 	def attach_pdf(self, outfile):
@@ -166,7 +161,7 @@ class Plugin(plugins.ClientPlugin):
 		try:
 			os.remove(self.config['output_pdf'])
 		except Exception as err:
-			self.logger.debug('Cannot delete created attachment: ' + repr(err))
+			self.logger.debug('cannot delete created attachment: ' + repr(err))
 		self.application.config['mailer.attachment_file'] = None
 
 	def expand_path(self, outfile, *args, **kwargs):


### PR DESCRIPTION
This PR does a lot of refactoring.

* Cleanup the reportlab imports
* Remove unnecessary whitespace
* Avoid overwritting the `style` name
* Ensure that all options are set in `signal_send_precheck`